### PR TITLE
Inline canvas gameplay on start

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,15 +31,50 @@ saveBtn.addEventListener('click', () => {
   saveOpts({ mute: optMute.checked, fullscreen: optFullscreen.checked });
 });
 
-startBtn.addEventListener('click', () => {
-  // pass options via query string; Godot page can read window.location.search if desired
-  const o = loadOpts();
-  const qs = new URLSearchParams({
-    mute: o.mute ? '1' : '0',
-    fs: o.fullscreen ? '1' : '0'
-  }).toString();
-  window.location.href = `/game/index.html?${qs}`;
-});
+startBtn.addEventListener('click', startGame);
+
+let player;
+let startTime;
+
+function startGame() {
+  // Old redirect logic removed; game now runs on this page.
+  // const o = loadOpts();
+  // const qs = new URLSearchParams({
+  //   mute: o.mute ? '1' : '0',
+  //   fs: o.fullscreen ? '1' : '0'
+  // }).toString();
+  // window.location.href = `/game/index.html?${qs}`;
+
+  // Hide the main menu container.
+  const menu = document.querySelector('main.container');
+  if (menu) menu.style.display = 'none';
+
+  // Create and display a canvas for gameplay.
+  const canvas = document.createElement('canvas');
+  canvas.id = 'gameCanvas';
+  canvas.width = 800;
+  canvas.height = 600;
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext('2d');
+
+  // Initialize game state.
+  player = { x: canvas.width / 2, y: canvas.height / 2, radius: 20 };
+  startTime = Date.now();
+
+  function loop() {
+    const elapsed = (Date.now() - startTime) / 1000;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.beginPath();
+    ctx.arc(player.x, player.y, player.radius, 0, Math.PI * 2);
+    ctx.fillStyle = 'blue';
+    ctx.fill();
+    ctx.fillStyle = 'black';
+    ctx.fillText(`Time: ${elapsed.toFixed(1)}`, 10, 20);
+    requestAnimationFrame(loop);
+  }
+
+  loop();
+}
 
 quitBtn.addEventListener('click', () => {
   // Web pages can't truly "quit". Give a graceful UX.


### PR DESCRIPTION
## Summary
- Replace start button redirect with `startGame` that launches a simple canvas-based demo
- Initialize player circle and timer while hiding the main menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b38ee48ed8833298f4d87ceef407b0