### PR TITLE
Add in-game quit button and direct cursor control

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,6 @@
       <button id="quitBtn" class="btn" role="menuitem">Quit</button>
     </nav>
 
-    <canvas id="gameCanvas"></canvas>
-
     <dialog id="optionsDialog">
       <form method="dialog" class="dialog-content">
         <h2>Options</h2>
@@ -39,6 +37,9 @@
 
     <p class="footnote">WebGL 2 + WASM build. Best in modern browsers.</p>
   </main>
+
+  <canvas id="gameCanvas"></canvas>
+  <button id="quitGameBtn" class="btn">Quit Game</button>
 
   <script src="./main.js" defer></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const LS_KEY = 'godot_web_options';
 const startBtn = document.getElementById('startBtn');
 const optionsBtn = document.getElementById('optionsBtn');
 const quitBtn = document.getElementById('quitBtn');
+const quitGameBtn = document.getElementById('quitGameBtn');
 const dlg = document.getElementById('optionsDialog');
 const optMute = document.getElementById('optMute');
 const optFullscreen = document.getElementById('optFullscreen');
@@ -83,9 +84,9 @@ function bindMouseOnce() {
 
 // ---------- Game loop ----------
 function draw() {
-  // spring toward target
-  posX += (targetX - posX) * 0.1;
-  posY += (targetY - posY) * 0.1;
+  // follow target directly
+  posX = targetX;
+  posY = targetY;
 
   ctx.clearRect(0, 0, gameCanvas.width, gameCanvas.height);
 
@@ -111,6 +112,7 @@ function startGame() {
 
   ensureCanvas();
   gameCanvas.style.display = 'block';
+  if (quitGameBtn) quitGameBtn.style.display = 'block';
   resizeCanvas();
   bindMouseOnce();
   window.addEventListener('resize', resizeCanvas);
@@ -141,12 +143,15 @@ function endGame() {
   if (gameCanvas) gameCanvas.style.display = 'none';
   if (container) container.style.display = 'block';
   if (menu) menu.style.display = '';
+  if (quitGameBtn) quitGameBtn.style.display = 'none';
 
   alert(caught ? 'You were caught!' : 'You escaped!');
 }
 
 // ---------- Hooks ----------
 startBtn.addEventListener('click', startGame);
+
+quitGameBtn?.addEventListener('click', endGame);
 
 quitBtn.addEventListener('click', () => {
   alert('Thanks for stopping by! You can close this tab any time.');

--- a/styles.css
+++ b/styles.css
@@ -32,3 +32,13 @@ dialog::backdrop { background: rgba(0,0,0,.55); }
   height: 100vh;
   display: none;
 }
+
+#quitGameBtn {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: none;
+  padding: .5rem .75rem;
+  font-size: .8rem;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
- Make player circle snap directly to cursor location
- Add overlay quit button to exit game loop and restore menu
- Style quit button for fixed overlay display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b39177b44c8332a5c828a8fb359886