### PR TITLE
Add animal sprites for player and enemies

### DIFF
--- a/assets/animals/cat.png
+++ b/assets/animals/cat.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9108387bbfd59f044fd68d04befcf86e2c9a46688583c0123d36be37442c5cc8
+size 299

--- a/assets/animals/dogs/beagle.png
+++ b/assets/animals/dogs/beagle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c62bd67a0d337607f262baba5712ea9cb2fd217965be040804f6d75badb2324
+size 322

--- a/assets/animals/dogs/bulldog.png
+++ b/assets/animals/dogs/bulldog.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d419bcd0bc43490e58949b4ac0af3350289df0174ea5306a1c15f5223cd98d16
+size 319

--- a/assets/animals/dogs/labrador.png
+++ b/assets/animals/dogs/labrador.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f860bc7c461be656f05fc860cf1cf2808cfbe1b4857ef7e85e9de7da751d5617
+size 255

--- a/main.js
+++ b/main.js
@@ -90,6 +90,16 @@ let mouse = { x: 0, y: 0, active: false };
 let enemies = [];
 let spawnTimer = 0; // secs until next spawn
 
+// Load sprites
+const dogSources = [
+  'assets/animals/dogs/beagle.png',
+  'assets/animals/dogs/labrador.png',
+  'assets/animals/dogs/bulldog.png'
+];
+const dogImages = dogSources.map(src => { const i = new Image(); i.src = src; return i; });
+const catImage = new Image();
+catImage.src = 'assets/animals/cat.png';
+
 function resetGame() {
   enemies = [];
   elapsed = 0;
@@ -112,7 +122,8 @@ function spawnEnemy() {
   // speed scales with time survived
   const base = 70, scale = 1 + (elapsed / TIME_LIMIT) * 1.6; // gets harder
   const speed = base * (0.9 + Math.random()*0.4) * scale; // px/sec
-  enemies.push({ x, y, r, speed, hue: Math.floor(0 + Math.random()*12)*30 });
+  const img = dogImages[Math.floor(Math.random()*dogImages.length)];
+  enemies.push({ x, y, r, speed, img });
 }
 
 function update(dt) {
@@ -183,17 +194,25 @@ function render() {
 
   // Enemies
   for (const e of enemies) {
-    ctx.beginPath();
-    ctx.fillStyle = `hsl(${e.hue}deg 80% 55%)`;
-    ctx.arc(e.x, e.y, e.r, 0, Math.PI*2);
-    ctx.fill();
+    if (e.img && e.img.complete) {
+      ctx.drawImage(e.img, e.x - e.r, e.y - e.r, e.r*2, e.r*2);
+    } else {
+      ctx.beginPath();
+      ctx.arc(e.x, e.y, e.r, 0, Math.PI*2);
+      ctx.fillStyle = '#fff';
+      ctx.fill();
+    }
   }
 
   // Player
-  ctx.beginPath();
-  ctx.fillStyle = '#5bd9ff';
-  ctx.arc(player.x, player.y, player.r, 0, Math.PI*2);
-  ctx.fill();
+  if (catImage.complete) {
+    ctx.drawImage(catImage, player.x - player.r, player.y - player.r, player.r*2, player.r*2);
+  } else {
+    ctx.beginPath();
+    ctx.fillStyle = '#000';
+    ctx.arc(player.x, player.y, player.r, 0, Math.PI*2);
+    ctx.fill();
+  }
 
   // Crosshair on mouse
   if (mouse.active) {


### PR DESCRIPTION
## Summary
- Add CC0 animal head sprites and preload them.
- Randomize enemy dogs from multiple breeds and draw player as a black cat.
- Render sprites scaled to match existing hitboxes.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m http.server 8000 &` (served index and assets)


------
https://chatgpt.com/codex/tasks/task_e_68b39784b8708332afb16ac405ecc9ff