### PR TITLE
feat: add backyard canvas background

### DIFF
--- a/assets/backyard.svg
+++ b/assets/backyard.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <defs>
+    <pattern id="fenceH" width="40" height="40" patternUnits="userSpaceOnUse">
+      <rect width="40" height="40" fill="#deb887"/>
+      <rect x="5" width="5" height="40" fill="#a0522d"/>
+      <rect x="20" width="5" height="40" fill="#a0522d"/>
+      <rect x="35" width="5" height="40" fill="#a0522d"/>
+    </pattern>
+    <pattern id="fenceV" width="40" height="40" patternUnits="userSpaceOnUse">
+      <rect width="40" height="40" fill="#deb887"/>
+      <rect y="5" width="40" height="5" fill="#a0522d"/>
+      <rect y="20" width="40" height="5" fill="#a0522d"/>
+      <rect y="35" width="40" height="5" fill="#a0522d"/>
+    </pattern>
+  </defs>
+  <rect width="800" height="600" fill="#7ec850"/>
+  <rect y="0" width="800" height="40" fill="url(#fenceH)"/>
+  <rect y="560" width="800" height="40" fill="url(#fenceH)"/>
+  <rect x="0" width="40" height="600" fill="url(#fenceV)"/>
+  <rect x="760" width="40" height="600" fill="url(#fenceV)"/>
+  <g transform="translate(520,340)">
+    <rect x="0" y="50" width="160" height="110" fill="#b5651d"/>
+    <polygon points="0,50 80,0 160,50" fill="#8b4513"/>
+    <ellipse cx="80" cy="115" rx="30" ry="40" fill="#000"/>
+  </g>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,7 @@ dialog::backdrop { background: rgba(0,0,0,.55); }
   height: 100vh;
   cursor: none;
   display: none;
+  background: url("./assets/backyard.svg") center/cover no-repeat;
 }
 
 #quitGameBtn {


### PR DESCRIPTION
## Summary
- style the game canvas with a backyard backdrop
- add a simple SVG yard asset with fences and a doghouse

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a22271808332a0e3ec7a9fbaead2