### PR TITLE
Add cannon tower with tracking bullets

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
   <div id="buildMenu" class="build-menu">
     <h3>Build Menu</h3>
     <button id="wallBtn" class="btn">Wall</button>
+    <button id="cannonBtn" class="btn">Cannon</button>
   </div>
 
   <script src="./main.js" defer></script>


### PR DESCRIPTION
## Summary
- add cannon tower to build menu
- fire slow homing bullets with scaling damage and pew sfx
- render and update towers as path-blocking obstacles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b715aae88332a8f0d3dc224dcf6e