### PR TITLE
Add tower management and basic economy

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,12 @@
     <button id="cannonBtn" class="btn">Cannon</button>
   </div>
 
+  <div id="towerMenu" class="tower-menu">
+    <button id="closeTowerMenu" class="close-btn">✖</button>
+    <button id="upgradeTower" class="btn">Upgrade</button>
+    <button id="sellTower" class="btn">Sell</button>
+  </div>
+
   <script src="./main.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -79,3 +79,31 @@ dialog::backdrop { background: rgba(0,0,0,.55); }
   margin: 0.25rem 0 0;
   cursor: pointer;
 }
+
+.tower-menu {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #fff;
+  border-radius: 8px;
+  padding: 0.5rem;
+  display: none;
+  z-index: 30;
+  width: 120px;
+}
+.tower-menu .btn {
+  background: rgba(255,255,255,0.1);
+  border: 1px solid #fff;
+  color: #fff;
+  margin: 0.25rem 0;
+  width: 100%;
+}
+.tower-menu .close-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- Add tower menu with upgrade and sell options and placeholder rank-up sound
- Track money from kills and waves, show in HUD, and play victory cheer
- Add bark placeholder when dogs are hit

## Testing
- `node --check main.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bd4478dc83328905ebf1e53fc562