### PR TITLE
Add lazer cannon tower with upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - add innovation mode with Overcharger tower, Aegis monster, and event cards
 - include sandbox simulation and debug overlay
+- introduce Lazer cannon tower with beam attack and stat upgrades

--- a/assets/lazer.svg
+++ b/assets/lazer.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="8" y="36" width="24" height="16" fill="#ccc" stroke="#000" stroke-width="2" />
+  <rect x="32" y="40" width="20" height="8" fill="#ddf" stroke="#000" stroke-width="2" />
+  <polygon points="52,40 62,44 52,48" fill="#f66" stroke="#000" stroke-width="2" />
+  <circle cx="20" cy="54" r="6" fill="#999" stroke="#000" stroke-width="2" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -53,11 +53,14 @@
       <div id="tab-build" class="tab-pane active">
         <button id="wallBtn" class="btn">Wall</button>
         <button id="cannonBtn" class="btn">Cannon</button>
+        <button id="lazerBtn" class="btn">Lazer</button>
         <button id="cancelBuildBtn" class="btn ghost">Cancel</button>
       </div>
       <div id="tab-upgrade" class="tab-pane">
         <p id="upgradeInfo">Select a tower</p>
-        <button id="upgradeTower" class="btn" disabled>Upgrade</button>
+        <button id="upgradeDamage" class="btn" disabled>Damage +</button>
+        <button id="upgradeSpeed" class="btn" disabled>Speed +</button>
+        <button id="upgradeRange" class="btn" disabled>Range +</button>
         <button id="sellTower" class="btn" disabled>Sell</button>
       </div>
       <div id="tab-stats" class="tab-pane">


### PR DESCRIPTION
## Summary
- introduce new lazer cannon tower with beam attack and zap sound
- provide damage, speed, and range upgrade buttons with stat tracking
- supply hand-drawn lazer cannon asset

## Testing
- `python scripts/tests/headless_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4d66695b88332852d8098b30ec63b