### PR TITLE
Delay build UI until game starts and shrink upgrade boxes

### DIFF
--- a/main.js
+++ b/main.js
@@ -1861,7 +1861,7 @@ async function startGame() {
   quitGameBtn && (quitGameBtn.style.display = 'inline-block');
   nextWaveBtn && (nextWaveBtn.style.display = 'inline-block');
   statsOverlay && (statsOverlay.style.display = 'block');
-  hoverMenu && (hoverMenu.style.display = 'block');
+  hoverMenu && (hoverMenu.style.display = 'flex');
 
   // Canvas
   

--- a/styles.css
+++ b/styles.css
@@ -613,6 +613,7 @@ dialog::backdrop {
   min-width: 200px;
   box-shadow: var(--game-shadow);
   z-index: 100;
+  display: none;
 }
 
 .overlay-header {
@@ -637,13 +638,13 @@ dialog::backdrop {
   backdrop-filter: blur(15px);
   border: 2px solid var(--game-border);
   border-radius: 12px;
-  box-shadow: 
+  box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     inset 0 1px 0 rgba(255, 255, 255, 0.1);
   z-index: 200;
   max-height: 80vh;
   overflow: hidden;
-  display: flex;
+  display: none;
   flex-direction: column;
 }
 
@@ -835,14 +836,14 @@ dialog::backdrop {
 .upgrade-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .upgrade-item {
   background: rgba(30, 41, 59, 0.3);
   border: 1px solid var(--game-border);
   border-radius: 6px;
-  padding: 0.75rem;
+  padding: 0.5rem;
   transition: all 0.2s ease;
 }
 
@@ -855,7 +856,7 @@ dialog::backdrop {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
 }
 
 .upgrade-label {
@@ -872,7 +873,7 @@ dialog::backdrop {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .current-value {
@@ -902,7 +903,7 @@ dialog::backdrop {
   color: white;
   border: none;
   border-radius: 4px;
-  padding: 0.4rem 0.8rem;
+  padding: 0.3rem 0.6rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -922,14 +923,14 @@ dialog::backdrop {
 .special-upgrade-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .special-upgrade-item {
   background: rgba(30, 41, 59, 0.3);
   border: 1px solid var(--game-border);
   border-radius: 4px;
-  padding: 0.75rem;
+  padding: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- Hide build menu and stats overlay until start of gameplay
- Reduce padding and gaps to make upgrade options more compact

## Testing
- `node tests/damage.test.js`
- `node tests/difficulty.test.js`
- `node tests/nuke_specialization.test.js`
- `node tests/railgun.test.js`
- `node tests/targeting.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6516367e083328ccf3d677503b111