### PR TITLE
Adjust build menu controls and upgrade sell placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,23 +184,16 @@
         <div class="tab-subtitle">Select a tower to build</div>
       </div>
       <div id="buildList" class="build-list"></div>
-      <div class="build-actions">
-        <button id="sellBuildBtn" class="btn sm ghost tactical" title="Sell Mode">
-          <span class="btn-icon">💰</span>
-          Sell
-        </button>
-        <button id="cancelBuildBtn" class="btn sm ghost tactical" title="Cancel Build">
-          <span class="btn-icon">❌</span>
-          Cancel
-        </button>
-      </div>
     </div>
 
     <div id="tab-upgrade" class="tab-content">
       <div id="selectedTowerInfo" class="tower-info">
-        <div class="no-selection">No tower selected</div>
+        <div class="tower-header">
+          <span id="selectedTowerName" class="tower-name no-selection">No tower selected</span>
+          <button id="sellTower" class="btn tactical sell-btn" disabled>Sell</button>
+        </div>
       </div>
-      
+
 <div id="upgradeOptions" class="upgrade-container">
   <div id="basicUpgrades" class="upgrade-section">
     <h4 class="section-title">Basic Upgrades</h4>
@@ -306,12 +299,6 @@
         </div>
       </div>
       
-      <div class="tower-actions">
-        <button id="sellTower" class="btn tactical sell-btn">
-          <span class="btn-icon">💰</span>
-          Sell Tower
-        </button>
-      </div>
     </div>
 
     <div id="tab-stats" class="tab-content">

--- a/main.js
+++ b/main.js
@@ -22,8 +22,6 @@ const hoverMenuHeader = document.getElementById('hoverMenuHeader');
 const tabButtons = document.querySelectorAll('.tab-btn');
 const tabContents = document.querySelectorAll('.tab-content');
 const buildList = document.getElementById('buildList');
-const cancelBuildBtn = document.getElementById('cancelBuildBtn');
-const sellBuildBtn = document.getElementById('sellBuildBtn');
 const upgradeDamageBtn = document.getElementById('upgradeDamage');
 const upgradeFireRateBtn = document.getElementById('upgradeFireRate');
 const upgradeRangeBtn = document.getElementById('upgradeRange');
@@ -31,7 +29,7 @@ const maxDamageBtn = document.getElementById('maxDamage');
 const maxFireRateBtn = document.getElementById('maxFireRate');
 const maxRangeBtn = document.getElementById('maxRange');
 const sellBtn = document.getElementById('sellTower');
-const selectedTowerInfo = document.getElementById('selectedTowerInfo');
+const selectedTowerName = document.getElementById('selectedTowerName');
 const damageValue = document.getElementById('damageValue');
 const damageNext = document.getElementById('damageNext');
 const damageCost = document.getElementById('damageCost');
@@ -451,8 +449,6 @@ function activateTab(name) {
   tabContents.forEach(c => c.classList.toggle('active', c.id === `tab-${name}`));
 }
 tabButtons.forEach(btn => btn.addEventListener('click', () => activateTab(btn.dataset.tab)));
-sellBuildBtn?.addEventListener('click', () => { selectedBuild = 'sell'; selectedTower = null; updateSelectedTowerInfo(); });
-cancelBuildBtn?.addEventListener('click', () => { selectedBuild = null; });
 
 let drag = null;
 hoverMenuHeader?.addEventListener('mousedown', (e) => {
@@ -557,13 +553,14 @@ pauseBtn?.addEventListener('click', () => {
 });
 
 function updateSelectedTowerInfo() {
-  if (!selectedTowerInfo) return;
+  if (!selectedTowerName) return;
   if (selectedTower) {
+    selectedTowerName.classList.remove('no-selection');
     const isSpecial = ['sniper','shotgun','dualLaser','railgun','nuke','hellfire'].includes(selectedTower.type);
     const fullyUpgraded = ['cannon','laser','rocket'].includes(selectedTower.type) && ['damage','fireRate','range'].every(s => selectedTower.upgrades?.[s] >= 10);
     rangePreview = { x: selectedTower.x, y: selectedTower.y, r: selectedTower.range * CELL_PX };
     if (fullyUpgraded) {
-      selectedTowerInfo.textContent = 'Choose specialization';
+      selectedTowerName.textContent = 'Choose specialization';
       if (basicUpgrades) basicUpgrades.style.display = 'none';
       if (specialUpgrades) {
         specialUpgrades.style.display = '';
@@ -600,7 +597,7 @@ function updateSelectedTowerInfo() {
       if (specialUpgrades) specialUpgrades.style.display = 'none';
       const friendlyNames = { sniper: 'Sniper', shotgun: 'Shotgun', dualLaser: 'Dual Laser', railgun: 'Railgun', nuke: 'Nuke', hellfire: 'Hellfire' };
       const typeName = friendlyNames[selectedTower.type] || selectedTower.type.charAt(0).toUpperCase() + selectedTower.type.slice(1);
-      selectedTowerInfo.textContent = isSpecial ? `${typeName} (Maxed)` : `Selected: ${selectedTower.type}`;
+      selectedTowerName.textContent = isSpecial ? `${typeName} (Maxed)` : `Selected: ${selectedTower.type}`;
       const stats = {
         damage: { value: damageValue, next: damageNext, cost: damageCost, btn: upgradeDamageBtn, maxBtn: maxDamageBtn },
         fireRate: { value: fireRateValue, next: fireRateNext, cost: fireRateCost, btn: upgradeFireRateBtn, maxBtn: maxFireRateBtn },
@@ -653,7 +650,8 @@ function updateSelectedTowerInfo() {
       sellBtn.disabled = false;
     }
   } else {
-    selectedTowerInfo.textContent = 'No tower selected';
+    selectedTowerName.textContent = 'No tower selected';
+    selectedTowerName.classList.add('no-selection');
     rangePreview = null;
     [damageValue, damageNext, damageCost, fireRateValue, fireRateNext, fireRateCost, rangeValue, rangeNext, rangeCost].forEach(el => {
       if (el) el.textContent = '-';

--- a/styles.css
+++ b/styles.css
@@ -825,14 +825,6 @@ dialog::backdrop {
   color: var(--game-text-muted);
 }
 
-.build-actions {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  padding-top: 1rem;
-  border-top: 1px solid var(--game-border);
-}
-
 /* Upgrade Tab */
 .tower-info {
   background: rgba(15, 20, 25, 0.5);
@@ -841,6 +833,13 @@ dialog::backdrop {
   padding: 1rem;
   margin-bottom: 1.5rem;
   text-align: center;
+}
+
+.tower-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .no-selection {
@@ -1036,13 +1035,6 @@ dialog::backdrop {
   background: var(--game-accent);
   color: white;
   transform: translateY(-1px);
-}
-
-.tower-actions {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--game-border);
-  text-align: center;
 }
 
 .sell-btn {


### PR DESCRIPTION
## Summary
- Remove sell and cancel controls from the Build tab tower list
- Move tower sell button next to selected tower heading on Upgrade tab
- Update styles and scripts to support new layout

## Testing
- `node tests/damage.test.js`
- `node tests/difficulty.test.js`
- `node tests/nuke_specialization.test.js`
- `node tests/railgun.test.js`
- `node tests/targeting.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6654da1608332aa3c71ac1b914d38