### PR TITLE
Replace tower fire sound placeholders with wav files

### DIFF
--- a/assets/towers/tower configurations/dualLaser-fire.txt
+++ b/assets/towers/tower configurations/dualLaser-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/dualLaser.json
+++ b/assets/towers/tower configurations/dualLaser.json
@@ -4,5 +4,5 @@
   "fireRate": 0.8,
   "range": 4,
   "cost": 1500,
-  "fireSound": "assets/towers/tower configurations/dualLaser-fire.txt"
+  "fireSound": "assets/towers/tower configurations/lazer-fire.wav"
 }

--- a/assets/towers/tower configurations/hellfire-fire.txt
+++ b/assets/towers/tower configurations/hellfire-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/hellfire.json
+++ b/assets/towers/tower configurations/hellfire.json
@@ -5,5 +5,5 @@
   "range": 5.5,
   "bulletSpeed": 4,
   "cost": 2000,
-  "fireSound": "assets/towers/tower configurations/hellfire-fire.txt"
+  "fireSound": "assets/towers/tower configurations/rocket-fire.wav"
 }

--- a/assets/towers/tower configurations/laser-fire.txt
+++ b/assets/towers/tower configurations/laser-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/laser.json
+++ b/assets/towers/tower configurations/laser.json
@@ -4,5 +4,5 @@
   "fireRate": 0.4,
   "range": 4,
   "cost": 100,
-  "fireSound": "assets/towers/tower configurations/laser-fire.txt"
+  "fireSound": "assets/towers/tower configurations/laser-fire.wav"
 }

--- a/assets/towers/tower configurations/nuke-fire.txt
+++ b/assets/towers/tower configurations/nuke-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/nuke.json
+++ b/assets/towers/tower configurations/nuke.json
@@ -5,5 +5,5 @@
   "range": 5.5,
   "bulletSpeed": 4,
   "cost": 3000,
-  "fireSound": "assets/towers/tower configurations/nuke-fire.txt"
+  "fireSound": "assets/towers/tower configurations/nuke-fire.wav"
 }

--- a/assets/towers/tower configurations/railgun-fire.txt
+++ b/assets/towers/tower configurations/railgun-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/railgun.json
+++ b/assets/towers/tower configurations/railgun.json
@@ -4,5 +4,5 @@
   "fireRate": 0.2,
   "range": 4,
   "cost": 2500,
-  "fireSound": "assets/towers/tower configurations/railgun-fire.txt"
+  "fireSound": "assets/towers/tower configurations/railgun-fire.wav"
 }

--- a/assets/towers/tower configurations/rocket-fire.txt
+++ b/assets/towers/tower configurations/rocket-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/rocket.json
+++ b/assets/towers/tower configurations/rocket.json
@@ -5,5 +5,5 @@
   "range": 5.5,
   "bulletSpeed": 4,
   "cost": 175,
-  "fireSound": "assets/towers/tower configurations/rocket-fire.txt"
+  "fireSound": "assets/towers/tower configurations/rocket-fire.wav"
 }

--- a/assets/towers/tower configurations/shotgun-fire.txt
+++ b/assets/towers/tower configurations/shotgun-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/shotgun.json
+++ b/assets/towers/tower configurations/shotgun.json
@@ -5,5 +5,5 @@
   "range": 4.5,
   "bulletSpeed": 5,
   "cost": 1200,
-  "fireSound": "assets/towers/tower configurations/shotgun-fire.txt"
+  "fireSound": "assets/towers/tower configurations/shotgun-fire.wav"
 }

--- a/assets/towers/tower configurations/sniper-fire.txt
+++ b/assets/towers/tower configurations/sniper-fire.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/assets/towers/tower configurations/sniper.json
+++ b/assets/towers/tower configurations/sniper.json
@@ -5,5 +5,5 @@
   "range": 6,
   "bulletSpeed": 8,
   "cost": 950,
-  "fireSound": "assets/towers/tower configurations/sniper-fire.txt"
+  "fireSound": "assets/towers/tower configurations/sniper-fire.wav"
 }


### PR DESCRIPTION
## Summary
- remove placeholder fire sound text files
- point tower configs to actual wav assets

## Testing
- `node tests/damage.test.js && node tests/difficulty.test.js && node tests/nuke_specialization.test.js && node tests/railgun.test.js && node tests/targeting.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b67a3c9bf08332816eb04916e16c0b