### PR TITLE
Add Tesla tower with lightning attack

### DIFF
--- a/assets/towers/tower configurations/tesla.json
+++ b/assets/towers/tower configurations/tesla.json
@@ -1,0 +1,8 @@
+{
+  "id": "tesla",
+  "damage": 400,
+  "fireRate": 0.3,
+  "range": 6,
+  "cost": 400,
+  "fireSound": "assets/towers/tower configurations/tesla_hit.wav"
+}


### PR DESCRIPTION
## Summary
- Introduce Tesla tower as a high-cost, high-damage option with long range and slow fire rate
- Load Tesla assets and config, enabling construction and lightning zap attacks
- Render dynamic zigzag lightning animation for Tesla strikes

## Testing
- `node tests/railgun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b793737fe4833295253a1750780b4a