### PR TITLE
feat: externalize map landmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 ## Unreleased
@@ -17,3 +18,5 @@
 - Slower boss base health scaling after each boss wave.
 - Show '(MAX!)' instead of the cost when a tower stat reaches level 10.
 - Added placeholder rocket and nuke hit sounds and silenced other bullet impacts.
+- Added per-map config files for grid size, enemy entries, and cat lives; removed dog-specific spawn and door data.
+

--- a/assets/maps/backyard/config.json
+++ b/assets/maps/backyard/config.json
@@ -1,0 +1,11 @@
+{
+  "name": "Backyard",
+  "img": "./assets/maps/backyard/backyard.png",
+  "grid": "medium",
+  "entries": [{ "x": 0, "y": 0 }],
+  "catLives": [
+    { "x": 24, "y": 11 }, { "x": 25, "y": 11 }, { "x": 26, "y": 11 },
+    { "x": 24, "y": 12 }, { "x": 25, "y": 12 }, { "x": 26, "y": 12 },
+    { "x": 24, "y": 13 }, { "x": 25, "y": 13 }, { "x": 26, "y": 13 }
+  ]
+}


### PR DESCRIPTION
## Summary
- load per-map configs for grid size, entries, and cat lives
- rely on map entries for enemy paths and spawning; remove dog door/spawn landmarks
- document map config structure

## Testing
- `node tests/railgun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b79869922483329e3cca0f1ad2a277