### PR TITLE
Add Terminator and Wunderwaffe Tesla upgrades

### DIFF
--- a/assets/towers/bases/D2_base.svg
+++ b/assets/towers/bases/D2_base.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-labelledby="title" data-emitter-center="21,7.8" data-emitter-rx="2" data-emitter-ry="1.05">
+  <title id="title">Lab-kitten next to Tesla tower base (coat aligned further right)</title>
+
+  <!-- ========== KITTEN (shifted left ~1.2px away from tower) ========== -->
+  <g id="kitten" transform="translate(-1.2,0)">
+    <!-- Body/Head/Tail -->
+    <g fill="currentColor" stroke="currentColor" stroke-width=".6" stroke-linejoin="round" stroke-linecap="round">
+      <!-- tail -->
+      <path d="M13.1 17.9c-1.2.1-2 .9-2 1.8 0 .8.6 1.5 1.3 1.5.3 0 .6-.1.6-.4 0-.2-.1-.3-.3-.4-.6-.2-.6-1.1.4-1.5"></path>
+      <!-- body -->
+      <ellipse cx="15.6" cy="15.2" rx="3.6" ry="4.4"></ellipse>
+      <!-- feet -->
+      <ellipse cx="14.0" cy="19.0" rx=".8" ry=".5"></ellipse>
+      <ellipse cx="17.2" cy="19.0" rx=".8" ry=".5"></ellipse>
+      <!-- head -->
+      <circle cx="15.4" cy="9.2" r="3.2"></circle>
+      <!-- ears -->
+      <path d="M13.7 7.1 14.6 5.4 15.3 7.0Z"></path>
+      <path d="M16.0 7.0 16.8 5.4 17.6 7.2Z"></path>
+      <!-- eyes -->
+      <g stroke="none">
+        <ellipse cx="14.7" cy="9.0" rx=".45" ry=".55" fill="#fff"></ellipse>
+        <ellipse cx="16.3" cy="9.0" rx=".45" ry=".55" fill="#fff"></ellipse>
+        <circle cx="14.8" cy="9.1" r=".2" fill="currentColor"></circle>
+        <circle cx="16.4" cy="9.1" r=".2" fill="currentColor"></circle>
+      </g>
+      <!-- muzzle + nose -->
+      <ellipse cx="15.5" cy="10.2" rx="1.2" ry=".9" fill="#fff" stroke="none" opacity=".9"></ellipse>
+      <path d="M15.2 9.9h.5l-.25.28Z" fill="currentColor" stroke="none"></path>
+      <!-- whiskers -->
+      <path d="M13.7 10.3h1.2M16.1 10.3h1.2M13.8 10.6h1.1M16.2 10.6h1.1" stroke-width=".35" fill="none"></path>
+    </g>
+
+    <!-- Goggles -->
+    <g stroke-linecap="round" stroke-linejoin="round">
+      <!-- strap -->
+      <path d="M13.0 8.6c.7-1.0 4.1-1.0 5.0 0" fill="none" stroke="#5c6670" stroke-width=".8"></path>
+      <!-- frames & lenses -->
+      <g fill="#9ad0ff" stroke="#2c3e50" stroke-width=".55" opacity=".9">
+        <ellipse cx="14.7" cy="9.0" rx=".85" ry=".75"></ellipse>
+        <ellipse cx="16.3" cy="9.0" rx=".85" ry=".75"></ellipse>
+        <rect x="15.05" y="8.75" width=".9" height=".4" rx=".15"></rect>
+      </g>
+      <!-- glare + buckles -->
+      <circle cx="14.5" cy="8.8" r=".12" fill="#fff" opacity=".8"></circle>
+      <circle cx="16.1" cy="8.8" r=".12" fill="#fff" opacity=".8"></circle>
+      <circle cx="13.7" cy="9.0" r=".1" fill="#2c3e50"></circle>
+      <circle cx="17.3" cy="9.0" r=".1" fill="#2c3e50"></circle>
+    </g>
+
+    <!-- Lab coat (smaller, nudged further right) -->
+    <g fill="#ffffff" stroke="#8a8f98" stroke-width=".6" stroke-linejoin="round" stroke-linecap="round" transform="translate(15,14) scale(0.9) translate(-15,-14) translate(1.4,0.4)">
+      <!-- coat body -->
+      <path d="M13.0 12.0c.6-1.0 1.8-1.8 2.6-1.8s2.0.8 2.6 1.8c.3.5.5 1.1.5 1.7 0 2.2-1.2 4.1-2.9 4.8-.6.3-1.8.3-2.4 0-1.7-.7-2.9-2.6-2.9-4.8 0-.6.2-1.2.5-1.7Z"></path>
+      <!-- lapels -->
+      <path d="M14.1 11.6l1.0 1.3 1.0-1.3" fill="none"></path>
+      <!-- center seam -->
+      <path d="M15.1 12.9v4.1" stroke="#a5acb6"></path>
+      <!-- buttons -->
+      <circle cx="15.1" cy="13.8" r=".13" fill="#a5acb6" stroke="none"></circle>
+      <circle cx="15.1" cy="15.0" r=".13" fill="#a5acb6" stroke="none"></circle>
+      <circle cx="15.1" cy="16.2" r=".13" fill="#a5acb6" stroke="none"></circle>
+      <!-- pocket + pen -->
+      <rect x="16.6" y="13.5" width="1.2" height=".9" rx=".15"></rect>
+      <path d="M17.0 13.45v.85" stroke="#2c3e50"></path>
+      <path d="M17.2 13.45v.75" stroke="#3bb273"></path>
+    </g>
+  </g>
+
+  <!-- ========== TESLA TOWER BASE (no top ball) ========== -->
+  <g stroke="#43464a" stroke-linejoin="round" stroke-linecap="round" stroke-width=".6">
+    <!-- emitter torus -->
+    <ellipse cx="21" cy="7.8" rx="2" ry="1.05" fill="#9aa3b1"></ellipse>
+    <!-- mast -->
+    <rect x="19.9" y="8.9" width="2.2" height="9.3" rx=".5" fill="#7b8591"></rect>
+    <!-- copper coil rings -->
+    <g stroke="#8b4e1f">
+      <path d="M20.2 10.2h1.6"></path>
+      <path d="M20.2 11.2h1.6"></path>
+      <path d="M20.2 12.2h1.6"></path>
+      <path d="M20.2 13.2h1.6"></path>
+      <path d="M20.2 14.2h1.6"></path>
+      <path d="M20.2 15.2h1.6"></path>
+      <path d="M20.2 16.2h1.6"></path>
+    </g>
+    <!-- base -->
+    <ellipse cx="21" cy="18.5" rx="1.5" ry=".5" fill="#9aa3b1"></ellipse>
+    <rect x="19" y="18.8" width="4" height="1.8" rx=".4" fill="#6f7a88"></rect>
+    <rect x="19.2" y="19.0" width="3.6" height=".7" rx=".2" fill="#444" stroke="#444"></rect>
+    <path d="M19.3 19.1l.5.6m.5-.6l.5.6m.5-.6l.5.6m.5-.6l.5.6" stroke="#f4c542"></path>
+  </g>
+
+  <!-- Guides -->
+  <g opacity="0">
+    <circle id="emitterCenter" cx="21" cy="7.8" r="0.01"></circle>
+  </g>
+</svg>

--- a/assets/towers/bases/terminator_base.svg
+++ b/assets/towers/bases/terminator_base.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-labelledby="title" data-emitter-center="21,7.8" data-emitter-rx="2" data-emitter-ry="1.05">
+  <title id="title">Lab-kitten next to Tesla tower base (coat aligned further right)</title>
+
+  <!-- ========== KITTEN (shifted left ~1.2px away from tower) ========== -->
+  <g id="kitten" transform="translate(-1.2,0)">
+    <!-- Body/Head/Tail -->
+    <g fill="currentColor" stroke="currentColor" stroke-width=".6" stroke-linejoin="round" stroke-linecap="round">
+      <!-- tail -->
+      <path d="M13.1 17.9c-1.2.1-2 .9-2 1.8 0 .8.6 1.5 1.3 1.5.3 0 .6-.1.6-.4 0-.2-.1-.3-.3-.4-.6-.2-.6-1.1.4-1.5"></path>
+      <!-- body -->
+      <ellipse cx="15.6" cy="15.2" rx="3.6" ry="4.4"></ellipse>
+      <!-- feet -->
+      <ellipse cx="14.0" cy="19.0" rx=".8" ry=".5"></ellipse>
+      <ellipse cx="17.2" cy="19.0" rx=".8" ry=".5"></ellipse>
+      <!-- head -->
+      <circle cx="15.4" cy="9.2" r="3.2"></circle>
+      <!-- ears -->
+      <path d="M13.7 7.1 14.6 5.4 15.3 7.0Z"></path>
+      <path d="M16.0 7.0 16.8 5.4 17.6 7.2Z"></path>
+      <!-- eyes -->
+      <g stroke="none">
+        <ellipse cx="14.7" cy="9.0" rx=".45" ry=".55" fill="#fff"></ellipse>
+        <ellipse cx="16.3" cy="9.0" rx=".45" ry=".55" fill="#fff"></ellipse>
+        <circle cx="14.8" cy="9.1" r=".2" fill="currentColor"></circle>
+        <circle cx="16.4" cy="9.1" r=".2" fill="currentColor"></circle>
+      </g>
+      <!-- muzzle + nose -->
+      <ellipse cx="15.5" cy="10.2" rx="1.2" ry=".9" fill="#fff" stroke="none" opacity=".9"></ellipse>
+      <path d="M15.2 9.9h.5l-.25.28Z" fill="currentColor" stroke="none"></path>
+      <!-- whiskers -->
+      <path d="M13.7 10.3h1.2M16.1 10.3h1.2M13.8 10.6h1.1M16.2 10.6h1.1" stroke-width=".35" fill="none"></path>
+    </g>
+
+    <!-- Goggles -->
+    <g stroke-linecap="round" stroke-linejoin="round">
+      <!-- strap -->
+      <path d="M13.0 8.6c.7-1.0 4.1-1.0 5.0 0" fill="none" stroke="#5c6670" stroke-width=".8"></path>
+      <!-- frames & lenses -->
+      <g fill="#9ad0ff" stroke="#2c3e50" stroke-width=".55" opacity=".9">
+        <ellipse cx="14.7" cy="9.0" rx=".85" ry=".75"></ellipse>
+        <ellipse cx="16.3" cy="9.0" rx=".85" ry=".75"></ellipse>
+        <rect x="15.05" y="8.75" width=".9" height=".4" rx=".15"></rect>
+      </g>
+      <!-- glare + buckles -->
+      <circle cx="14.5" cy="8.8" r=".12" fill="#fff" opacity=".8"></circle>
+      <circle cx="16.1" cy="8.8" r=".12" fill="#fff" opacity=".8"></circle>
+      <circle cx="13.7" cy="9.0" r=".1" fill="#2c3e50"></circle>
+      <circle cx="17.3" cy="9.0" r=".1" fill="#2c3e50"></circle>
+    </g>
+
+    <!-- Lab coat (smaller, nudged further right) -->
+    <g fill="#ffffff" stroke="#8a8f98" stroke-width=".6" stroke-linejoin="round" stroke-linecap="round" transform="translate(15,14) scale(0.9) translate(-15,-14) translate(1.4,0.4)">
+      <!-- coat body -->
+      <path d="M13.0 12.0c.6-1.0 1.8-1.8 2.6-1.8s2.0.8 2.6 1.8c.3.5.5 1.1.5 1.7 0 2.2-1.2 4.1-2.9 4.8-.6.3-1.8.3-2.4 0-1.7-.7-2.9-2.6-2.9-4.8 0-.6.2-1.2.5-1.7Z"></path>
+      <!-- lapels -->
+      <path d="M14.1 11.6l1.0 1.3 1.0-1.3" fill="none"></path>
+      <!-- center seam -->
+      <path d="M15.1 12.9v4.1" stroke="#a5acb6"></path>
+      <!-- buttons -->
+      <circle cx="15.1" cy="13.8" r=".13" fill="#a5acb6" stroke="none"></circle>
+      <circle cx="15.1" cy="15.0" r=".13" fill="#a5acb6" stroke="none"></circle>
+      <circle cx="15.1" cy="16.2" r=".13" fill="#a5acb6" stroke="none"></circle>
+      <!-- pocket + pen -->
+      <rect x="16.6" y="13.5" width="1.2" height=".9" rx=".15"></rect>
+      <path d="M17.0 13.45v.85" stroke="#2c3e50"></path>
+      <path d="M17.2 13.45v.75" stroke="#3bb273"></path>
+    </g>
+  </g>
+
+  <!-- ========== TESLA TOWER BASE (no top ball) ========== -->
+  <g stroke="#43464a" stroke-linejoin="round" stroke-linecap="round" stroke-width=".6">
+    <!-- emitter torus -->
+    <ellipse cx="21" cy="7.8" rx="2" ry="1.05" fill="#9aa3b1"></ellipse>
+    <!-- mast -->
+    <rect x="19.9" y="8.9" width="2.2" height="9.3" rx=".5" fill="#7b8591"></rect>
+    <!-- copper coil rings -->
+    <g stroke="#8b4e1f">
+      <path d="M20.2 10.2h1.6"></path>
+      <path d="M20.2 11.2h1.6"></path>
+      <path d="M20.2 12.2h1.6"></path>
+      <path d="M20.2 13.2h1.6"></path>
+      <path d="M20.2 14.2h1.6"></path>
+      <path d="M20.2 15.2h1.6"></path>
+      <path d="M20.2 16.2h1.6"></path>
+    </g>
+    <!-- base -->
+    <ellipse cx="21" cy="18.5" rx="1.5" ry=".5" fill="#9aa3b1"></ellipse>
+    <rect x="19" y="18.8" width="4" height="1.8" rx=".4" fill="#6f7a88"></rect>
+    <rect x="19.2" y="19.0" width="3.6" height=".7" rx=".2" fill="#444" stroke="#444"></rect>
+    <path d="M19.3 19.1l.5.6m.5-.6l.5.6m.5-.6l.5.6m.5-.6l.5.6" stroke="#f4c542"></path>
+  </g>
+
+  <!-- Guides -->
+  <g opacity="0">
+    <circle id="emitterCenter" cx="21" cy="7.8" r="0.01"></circle>
+  </g>
+</svg>

--- a/assets/towers/tower configurations/terminator.json
+++ b/assets/towers/tower configurations/terminator.json
@@ -1,0 +1,8 @@
+{
+  "id": "terminator",
+  "damage": 480,
+  "fireRate": 0.36,
+  "range": 6,
+  "cost": 2200,
+  "fireSound": "assets/towers/tower configurations/tesla_hit.wav"
+}

--- a/assets/towers/tower configurations/wunderwaffe.json
+++ b/assets/towers/tower configurations/wunderwaffe.json
@@ -1,0 +1,8 @@
+{
+  "id": "wunderwaffe",
+  "damage": 600,
+  "fireRate": 0.225,
+  "range": 6,
+  "cost": 2600,
+  "fireSound": "assets/towers/tower configurations/tesla_hit.wav"
+}

--- a/assets/towers/turrets/D2_turret.svg
+++ b/assets/towers/turrets/D2_turret.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-labelledby="title" data-target-ball-center="21,6.1" data-target-ball-radius="0.95">
+  <title id="title">Tower top targeting ball (overlay)</title>
+
+  <!-- Rotate this group toward targets -->
+  <g id="targetBall" transform="rotate(0 21 6.1)">
+    <!-- ball shell -->
+    <circle cx="21" cy="6.1" r="0.95" fill="#9aa3b1" stroke="#43464a" stroke-width=".6"></circle>
+    <!-- rim band (equator) -->
+    <ellipse cx="21" cy="6.1" rx="0.9" ry="0.28" fill="#7b8591" opacity=".55" stroke="none"></ellipse>
+    <!-- directional slit (shows facing when rotated) -->
+    <path d="M21.25 6.1h.55" stroke="#2b2f36" stroke-width=".35" stroke-linecap="round"></path>
+    <!-- accent chevron -->
+    <path d="M20.9 5.7l.6.4-.6.4" fill="none" stroke="#6c7682" stroke-width=".35" stroke-linecap="round" stroke-linejoin="round" opacity=".9"></path>
+    <!-- LED -->
+    <circle cx="20.55" cy="5.85" r="0.1" fill="#00e676"></circle>
+    <!-- highlight & shadow -->
+    <circle cx="20.7" cy="5.85" r="0.28" fill="#ffffff" opacity=".5" stroke="none"></circle>
+    <path d="M21.9 6.1a.9.9 0 0 1-1.5.7" fill="#6f7a88" opacity=".35" stroke="none"></path>
+  </g>
+
+  <!-- Optional tiny mounting post (enable if you want a visible stem) -->
+  <g id="mountPost" fill="#7b8591" stroke="#43464a" stroke-width=".5" style="display:none">
+    <rect x="20.78" y="7.1" width=".44" height=".7" rx=".2"></rect>
+  </g>
+
+  <!-- Guide for tooling -->
+  <g opacity="0">
+    <circle id="pivot" cx="21" cy="6.1" r="0.01"></circle>
+  </g>
+</svg>

--- a/assets/towers/turrets/terminator_turret.svg
+++ b/assets/towers/turrets/terminator_turret.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-labelledby="title" data-target-ball-center="21,6.1" data-target-ball-radius="0.95">
+  <title id="title">Tower top targeting ball (overlay)</title>
+
+  <!-- Rotate this group toward targets -->
+  <g id="targetBall" transform="rotate(0 21 6.1)">
+    <!-- ball shell -->
+    <circle cx="21" cy="6.1" r="0.95" fill="#9aa3b1" stroke="#43464a" stroke-width=".6"></circle>
+    <!-- rim band (equator) -->
+    <ellipse cx="21" cy="6.1" rx="0.9" ry="0.28" fill="#7b8591" opacity=".55" stroke="none"></ellipse>
+    <!-- directional slit (shows facing when rotated) -->
+    <path d="M21.25 6.1h.55" stroke="#2b2f36" stroke-width=".35" stroke-linecap="round"></path>
+    <!-- accent chevron -->
+    <path d="M20.9 5.7l.6.4-.6.4" fill="none" stroke="#6c7682" stroke-width=".35" stroke-linecap="round" stroke-linejoin="round" opacity=".9"></path>
+    <!-- LED -->
+    <circle cx="20.55" cy="5.85" r="0.1" fill="#00e676"></circle>
+    <!-- highlight & shadow -->
+    <circle cx="20.7" cy="5.85" r="0.28" fill="#ffffff" opacity=".5" stroke="none"></circle>
+    <path d="M21.9 6.1a.9.9 0 0 1-1.5.7" fill="#6f7a88" opacity=".35" stroke="none"></path>
+  </g>
+
+  <!-- Optional tiny mounting post (enable if you want a visible stem) -->
+  <g id="mountPost" fill="#7b8591" stroke="#43464a" stroke-width=".5" style="display:none">
+    <rect x="20.78" y="7.1" width=".44" height=".7" rx=".2"></rect>
+  </g>
+
+  <!-- Guide for tooling -->
+  <g opacity="0">
+    <circle id="pivot" cx="21" cy="6.1" r="0.01"></circle>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -307,6 +307,22 @@
               <span id="hellfireCost" class="special-cost"></span>
               <button id="upgradeHellfire" class="btn sm special-btn">Select</button>
             </div>
+            <div class="special-option">
+              <div class="special-info">
+                <span class="special-icon">🤖</span>
+                <span class="special-name">Terminator</span>
+              </div>
+              <span id="terminatorCost" class="special-cost"></span>
+              <button id="upgradeTerminator" class="btn sm special-btn">Select</button>
+            </div>
+            <div class="special-option">
+              <div class="special-info">
+                <span class="special-icon">⚡</span>
+                <span class="special-name">Wunderwaffe</span>
+              </div>
+              <span id="wunderwaffeCost" class="special-cost"></span>
+              <button id="upgradeWunderwaffe" class="btn sm special-btn">Select</button>
+            </div>
           </div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -52,12 +52,16 @@ const upgradeDualLaserBtn = document.getElementById('upgradeDualLaser');
 const upgradeRailgunBtn = document.getElementById('upgradeRailgun');
 const upgradeNukeBtn = document.getElementById('upgradeNuke');
 const upgradeHellfireBtn = document.getElementById('upgradeHellfire');
+const upgradeTerminatorBtn = document.getElementById('upgradeTerminator');
+const upgradeWunderwaffeBtn = document.getElementById('upgradeWunderwaffe');
 const sniperCostSpan = document.getElementById('sniperCost');
 const shotgunCostSpan = document.getElementById('shotgunCost');
 const dualLaserCostSpan = document.getElementById('dualLaserCost');
 const railgunCostSpan = document.getElementById('railgunCost');
 const nukeCostSpan = document.getElementById('nukeCost');
 const hellfireCostSpan = document.getElementById('hellfireCost');
+const terminatorCostSpan = document.getElementById('terminatorCost');
+const wunderwaffeCostSpan = document.getElementById('wunderwaffeCost');
 const quitInMenuBtn = document.getElementById('quitInMenuBtn');
 const pauseBtn = document.getElementById('pauseBtn');
 const contextMenu = document.getElementById('contextMenu');
@@ -130,7 +134,9 @@ const BALANCE = {
     dualLaser: 1500,
     railgun: 2500,
     nuke: 3000,
-    hellfire: 2000
+    hellfire: 2000,
+    terminator: 2200,
+    wunderwaffe: 2600
   },
   difficulties: {
     easy: { startingCash: 500, killReward: 15, waveReward: 75, healthMultiplier: 0.8 },
@@ -157,6 +163,8 @@ dualLaserCostSpan && (dualLaserCostSpan.textContent = `$${BALANCE.specialization
 railgunCostSpan && (railgunCostSpan.textContent = `$${BALANCE.specializationCosts.railgun}`);
 nukeCostSpan && (nukeCostSpan.textContent = `$${BALANCE.specializationCosts.nuke}`);
 hellfireCostSpan && (hellfireCostSpan.textContent = `$${BALANCE.specializationCosts.hellfire}`);
+terminatorCostSpan && (terminatorCostSpan.textContent = `$${BALANCE.specializationCosts.terminator}`);
+wunderwaffeCostSpan && (wunderwaffeCostSpan.textContent = `$${BALANCE.specializationCosts.wunderwaffe}`);
 
 const GRID_SIZES = {
   large: { cols: 36, rows: 24 },
@@ -600,6 +608,12 @@ upgradeNukeBtn?.addEventListener('click', () => {
 upgradeHellfireBtn?.addEventListener('click', () => {
   if (selectedTower) { specializeTower(selectedTower, 'hellfire'); updateSelectedTowerInfo(); }
 });
+upgradeTerminatorBtn?.addEventListener('click', () => {
+  if (selectedTower) { specializeTower(selectedTower, 'terminator'); updateSelectedTowerInfo(); }
+});
+upgradeWunderwaffeBtn?.addEventListener('click', () => {
+  if (selectedTower) { specializeTower(selectedTower, 'wunderwaffe'); updateSelectedTowerInfo(); }
+});
 quitInMenuBtn?.addEventListener('click', () => returnToMenu());
 
 pauseBtn?.addEventListener('click', () => {
@@ -620,8 +634,8 @@ function updateSelectedTowerInfo() {
   if (!selectedTowerName) return;
   if (selectedTower) {
     selectedTowerName.classList.remove('no-selection');
-    const isSpecial = ['sniper','shotgun','dualLaser','railgun','nuke','hellfire'].includes(selectedTower.type);
-    const fullyUpgraded = ['cannon','laser','rocket'].includes(selectedTower.type) && ['damage','fireRate','range'].every(s => selectedTower.upgrades?.[s] >= 10);
+    const isSpecial = ['sniper','shotgun','dualLaser','railgun','nuke','hellfire','terminator','wunderwaffe'].includes(selectedTower.type);
+    const fullyUpgraded = ['cannon','laser','rocket','tesla'].includes(selectedTower.type) && ['damage','fireRate','range'].every(s => selectedTower.upgrades?.[s] >= 10);
     rangePreview = { x: selectedTower.x, y: selectedTower.y, r: selectedTower.range * CELL_PX };
     if (fullyUpgraded) {
       selectedTowerName.textContent = 'Choose specialization';
@@ -631,6 +645,7 @@ function updateSelectedTowerInfo() {
         const isCannon = selectedTower.type === 'cannon';
         const isLaser = selectedTower.type === 'laser';
         const isRocket = selectedTower.type === 'rocket';
+        const isTesla = selectedTower.type === 'tesla';
         if (upgradeSniperBtn) {
           upgradeSniperBtn.parentElement && (upgradeSniperBtn.parentElement.style.display = isCannon ? '' : 'none');
           upgradeSniperBtn.disabled = money < BALANCE.specializationCosts.sniper;
@@ -655,11 +670,19 @@ function updateSelectedTowerInfo() {
           upgradeHellfireBtn.parentElement && (upgradeHellfireBtn.parentElement.style.display = isRocket ? '' : 'none');
           upgradeHellfireBtn.disabled = money < BALANCE.specializationCosts.hellfire;
         }
+        if (upgradeTerminatorBtn) {
+          upgradeTerminatorBtn.parentElement && (upgradeTerminatorBtn.parentElement.style.display = isTesla ? '' : 'none');
+          upgradeTerminatorBtn.disabled = money < BALANCE.specializationCosts.terminator;
+        }
+        if (upgradeWunderwaffeBtn) {
+          upgradeWunderwaffeBtn.parentElement && (upgradeWunderwaffeBtn.parentElement.style.display = isTesla ? '' : 'none');
+          upgradeWunderwaffeBtn.disabled = money < BALANCE.specializationCosts.wunderwaffe;
+        }
       }
     } else {
       if (basicUpgrades) basicUpgrades.style.display = '';
       if (specialUpgrades) specialUpgrades.style.display = 'none';
-      const friendlyNames = { sniper: 'Sniper', shotgun: 'Shotgun', dualLaser: 'Dual Laser', railgun: 'Railgun', nuke: 'Nuke', hellfire: 'Hellfire' };
+      const friendlyNames = { sniper: 'Sniper', shotgun: 'Shotgun', dualLaser: 'Dual Laser', railgun: 'Railgun', nuke: 'Nuke', hellfire: 'Hellfire', terminator: 'Terminator', wunderwaffe: 'Wunderwaffe' };
       const typeName = friendlyNames[selectedTower.type] || selectedTower.type.charAt(0).toUpperCase() + selectedTower.type.slice(1);
       selectedTowerName.textContent = isSpecial ? `${typeName} (Maxed)` : `Selected: ${selectedTower.type}`;
       const stats = {
@@ -872,6 +895,20 @@ function specializeTower(t, kind) {
     } else {
       return;
     }
+  } else if (t.type === 'tesla') {
+    if (kind === 'terminator') {
+      t.type = 'terminator';
+      t.damage = Math.round(t.damage * 1.2);
+      t.fireRate = t.fireRate * 1.2;
+      // range unchanged
+    } else if (kind === 'wunderwaffe') {
+      t.type = 'wunderwaffe';
+      t.damage = Math.round(t.damage * 1.5);
+      t.fireRate = t.fireRate * 0.75;
+      // range unchanged
+    } else {
+      return;
+    }
   } else {
     return;
   }
@@ -962,6 +999,10 @@ const SHOTGUN_BASE_SRC = 'assets/towers/bases/tower_base.svg';
 const SHOTGUN_TURRET_SRC = 'assets/towers/turrets/shotgun_turret.svg';
 const TESLA_BASE_SRC = 'assets/towers/bases/tesla_base.svg';
 const TESLA_TURRET_SRC = 'assets/towers/turrets/tesla_turret.svg';
+const TERMINATOR_BASE_SRC = 'assets/towers/bases/terminator_base.svg';
+const TERMINATOR_TURRET_SRC = 'assets/towers/turrets/terminator_turret.svg';
+const WUNDERWAFFE_BASE_SRC = 'assets/towers/bases/D2_base.svg';
+const WUNDERWAFFE_TURRET_SRC = 'assets/towers/turrets/D2_turret.svg';
 const WAVE_START_SOUND = 'assets/sounds/wave_start.wav';
 const WAVE_COMPLETE_SOUND = 'assets/sounds/wave_complete.wav';
 const BOSS_WAVE_START_SOUND = 'assets/sounds/boss_wave_start.wav';
@@ -977,7 +1018,9 @@ const TOWER_CONFIG_IDS = [
   'railgun',
   'nuke',
   'hellfire',
-  'tesla'
+  'tesla',
+  'terminator',
+  'wunderwaffe'
 ];
 
 let DATA_LOADED = false;
@@ -1041,7 +1084,9 @@ let ASSETS = {
   railgun: { base: null, turret: null },
   sniper: { base: null, turret: null },
   shotgun: { base: null, turret: null },
-  tesla: { base: null, turret: null }
+  tesla: { base: null, turret: null },
+  terminator: { base: null, turret: null },
+  wunderwaffe: { base: null, turret: null }
 };
 let assetsReady; // Promise
 
@@ -1064,7 +1109,9 @@ async function ensureAssets() {
           railgun: { base: await loadImage(RAILGUN_BASE_SRC), turret: await loadImage(RAILGUN_TURRET_SRC) },
           sniper: { base: await loadImage(SNIPER_BASE_SRC), turret: await loadImage(SNIPER_TURRET_SRC) },
           shotgun: { base: await loadImage(SHOTGUN_BASE_SRC), turret: await loadImage(SHOTGUN_TURRET_SRC) },
-          tesla: { base: await loadImage(TESLA_BASE_SRC), turret: await loadImage(TESLA_TURRET_SRC) }
+          tesla: { base: await loadImage(TESLA_BASE_SRC), turret: await loadImage(TESLA_TURRET_SRC) },
+          terminator: { base: await loadImage(TERMINATOR_BASE_SRC), turret: await loadImage(TERMINATOR_TURRET_SRC) },
+          wunderwaffe: { base: await loadImage(WUNDERWAFFE_BASE_SRC), turret: await loadImage(WUNDERWAFFE_TURRET_SRC) }
         };
     })();
   }
@@ -1394,6 +1441,10 @@ function updateProjectiles(dt) {
   });
 
   zaps = zaps.filter(z => {
+    if (z.delay) {
+      z.delay -= dt;
+      if (z.delay > 0) return true;
+    }
     z.time -= dt;
     return z.time > 0;
   });
@@ -1486,9 +1537,19 @@ function update(dt) {
     const rangePx = t.range * CELL_PX;
     let target = null;
     let closest = rangePx;
+    let possible = [];
     for (const e of enemies) {
       const d = Math.hypot(e.x - t.x, e.y - t.y);
-      if (d <= closest) { target = e; closest = d; }
+      if (d <= rangePx) {
+        if (d <= closest) { target = e; closest = d; }
+        if (t.type === 'terminator') possible.push({ e, d });
+      }
+    }
+    if (t.type === 'terminator') {
+      possible.sort((a, b) => a.d - b.d);
+      t.targets = possible.slice(0, 5).map(p => p.e);
+    } else {
+      t.targets = null;
     }
     t.target = target;
     if (target) {
@@ -1581,6 +1642,46 @@ function update(dt) {
             money += killReward;
             t.kills = (t.kills || 0) + 1;
         }
+      } else if (t.type === 'terminator') {
+        const targets = t.targets || [];
+        if (targets.length) {
+          for (const e of targets) {
+            const ang = Math.atan2(e.y - t.y, e.x - t.x);
+            const x1 = t.x + Math.cos(ang) * (CELL_PX / 2);
+            const y1 = t.y + Math.sin(ang) * (CELL_PX / 2);
+            const points = createZap(x1, y1, e.x, e.y);
+            zaps.push({ points, time: 0.1, colors: ['#f88','#f00'] });
+            e.health -= t.damage;
+            if (e.health <= 0) {
+              enemies.splice(enemies.indexOf(e), 1);
+              money += killReward;
+              t.kills = (t.kills || 0) + 1;
+            }
+          }
+          t.cooldown = 1 / t.fireRate;
+          playFireSound(t);
+        }
+      } else if (t.type === 'wunderwaffe') {
+        const angle = t.angle;
+        let x1 = t.x + Math.cos(angle) * (CELL_PX / 2);
+        let y1 = t.y + Math.sin(angle) * (CELL_PX / 2);
+        let delay = 0;
+        const chain = enemies.slice();
+        const idx = chain.indexOf(target);
+        if (idx > -1) { chain.splice(idx,1); chain.unshift(target); }
+        for (const e of chain) {
+          const points = createZap(x1, y1, e.x, e.y);
+          zaps.push({ points, time: 0.1, delay });
+          e.health -= t.damage;
+          if (e.health <= 0) {
+            enemies.splice(enemies.indexOf(e), 1);
+            money += killReward;
+            t.kills = (t.kills || 0) + 1;
+          }
+          x1 = e.x; y1 = e.y; delay += 0.05;
+        }
+        t.cooldown = 1 / t.fireRate;
+        playFireSound(t);
       } else if (t.type === 'railgun') {
         const angle = t.angle;
         const dx = Math.cos(angle);
@@ -1738,6 +1839,8 @@ function render() {
       const art = t.type === 'laser' ? ASSETS.laser :
         t.type === 'rocket' ? ASSETS.rocket :
         t.type === 'tesla' ? ASSETS.tesla :
+        t.type === 'terminator' ? ASSETS.terminator :
+        t.type === 'wunderwaffe' ? ASSETS.wunderwaffe :
         t.type === 'nuke' ? ASSETS.nuke :
         t.type === 'hellfire' ? ASSETS.hellfire :
         t.type === 'dualLaser' ? ASSETS.dualLaser :
@@ -1797,10 +1900,11 @@ function render() {
 
   // Zaps
   for (const zap of zaps) {
+    if (zap.delay && zap.delay > 0) continue;
     const pts = zap.points;
+    const cols = zap.colors || ['#ccf', '#66f'];
     const grad = ctx.createLinearGradient(pts[0].x, pts[0].y, pts[pts.length - 1].x, pts[pts.length - 1].y);
-    grad.addColorStop(0, '#ccf');
-    grad.addColorStop(1, '#66f');
+    cols.forEach((c, i) => grad.addColorStop(cols.length === 1 ? 0 : i / (cols.length - 1), c));
     ctx.strokeStyle = grad;
     ctx.lineWidth = 2;
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- add Terminator and Wunderwaffe specializations for the Tesla tower
- allow Tesla towers to upgrade into multi-target or chain lightning variants with unique assets
- support colored and delayed lightning effects for specialized towers

## Testing
- `node tests/railgun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7bf3ee5ec83329dce8f60dc98c3b7