### PR TITLE
Hide game canvas until mission starts

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
             </form>
         </dialog>
     </main>
-<canvas id="gameCanvas"></canvas>
+<canvas id="gameCanvas" style="display:none"></canvas>
 
 <div id="statsOverlay" class="stats-overlay">
   <div class="overlay-header">


### PR DESCRIPTION
## Summary
- hide the game canvas by default so scrolling the menu no longer reveals the map

## Testing
- `node tests/railgun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bce74905d08332870915c56290d3f8