### PR TITLE
Refine loadout and build menus for better spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,16 +101,15 @@
                         <input type="checkbox" id="optFullscreen" checked>
                     </label>
                     <label class="row">
-                        <span>Override grid size</span>
-                        <input type="checkbox" id="optGridOverride">
-                    </label>
-                    <label class="row">
                         <span>Grid size</span>
-                        <select id="optGridSize" disabled>
-                            <option value="large">large – 36×24</option>
-                            <option value="medium" selected>medium – 30×20</option>
-                            <option value="small">small – 24×16</option>
-                        </select>
+                        <div class="grid-size-control">
+                            <input type="checkbox" id="optGridOverride">
+                            <select id="optGridSize" disabled>
+                                <option value="large">large – 36×24</option>
+                                <option value="medium" selected>medium – 30×20</option>
+                                <option value="small">small – 24×16</option>
+                            </select>
+                        </div>
                     </label>
                     <label class="row">
                         <span>Difficulty</span>

--- a/index.html
+++ b/index.html
@@ -91,35 +91,37 @@
         <dialog id="optionsDialog">
             <form method="dialog" class="dialog-content">
                 <h2>Loadout</h2>
-                <label class="row">
-                    <span>Mute audio</span>
-                    <input type="checkbox" id="optMute">
-                </label>
-                <label class="row">
-                    <span>Start in fullscreen</span>
-                    <input type="checkbox" id="optFullscreen" checked>
-                </label>
-                <label class="row">
-                    <span>Override grid size</span>
-                    <input type="checkbox" id="optGridOverride">
-                </label>
-                <label class="row">
-                    <span>Grid size</span>
-                    <select id="optGridSize" disabled>
-                        <option value="large">large – 36×24</option>
-                        <option value="medium" selected>medium – 30×20</option>
-                        <option value="small">small – 24×16</option>
-                    </select>
-                </label>
-                <label class="row">
-                    <span>Difficulty</span>
-                    <select id="optDifficulty">
-                        <option value="easy">easy</option>
-                        <option value="medium" selected>medium</option>
-                        <option value="hard">hard</option>
-                        <option value="free">free mode</option>
-                    </select>
-                </label>
+                <div class="options-grid">
+                    <label class="row">
+                        <span>Mute audio</span>
+                        <input type="checkbox" id="optMute">
+                    </label>
+                    <label class="row">
+                        <span>Start in fullscreen</span>
+                        <input type="checkbox" id="optFullscreen" checked>
+                    </label>
+                    <label class="row">
+                        <span>Override grid size</span>
+                        <input type="checkbox" id="optGridOverride">
+                    </label>
+                    <label class="row">
+                        <span>Grid size</span>
+                        <select id="optGridSize" disabled>
+                            <option value="large">large – 36×24</option>
+                            <option value="medium" selected>medium – 30×20</option>
+                            <option value="small">small – 24×16</option>
+                        </select>
+                    </label>
+                    <label class="row">
+                        <span>Difficulty</span>
+                        <select id="optDifficulty">
+                            <option value="easy">easy</option>
+                            <option value="medium" selected>medium</option>
+                            <option value="hard">hard</option>
+                            <option value="free">free mode</option>
+                        </select>
+                    </label>
+                </div>
                 <menu class="dialog-actions">
                     <button value="cancel" class="btn ghost">Cancel</button>
                     <button id="saveOptions" value="default" class="btn tactical">Save</button>
@@ -193,10 +195,6 @@
 
   <div class="tab-container">
     <div id="tab-build" class="tab-content active">
-      <div class="tab-header">
-        <h3>Build Towers</h3>
-        <div class="tab-subtitle">Select a tower to build</div>
-      </div>
       <div id="buildList" class="build-list"></div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>My Godot Web Game</title>
+  <title>DogHouse: Tower Defense!</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="preload" href="/game/godot.wasm" as="fetch" type="application/wasm" crossorigin>
   <link rel="stylesheet" href="./styles.css" />

--- a/index.html
+++ b/index.html
@@ -100,17 +100,17 @@
                         <span>Start in fullscreen</span>
                         <input type="checkbox" id="optFullscreen" checked>
                     </label>
-                    <label class="row">
-                        <span>Grid size</span>
-                        <div class="grid-size-control">
+                    <div class="row grid-size-option">
+                        <div class="checkbox-line">
+                            <label for="optGridOverride">Grid size override</label>
                             <input type="checkbox" id="optGridOverride">
-                            <select id="optGridSize" disabled>
-                                <option value="large">large – 36×24</option>
-                                <option value="medium" selected>medium – 30×20</option>
-                                <option value="small">small – 24×16</option>
-                            </select>
                         </div>
-                    </label>
+                        <select id="optGridSize" disabled>
+                            <option value="large">large – 36×24</option>
+                            <option value="medium" selected>medium – 30×20</option>
+                            <option value="small">small – 24×16</option>
+                        </select>
+                    </div>
                     <label class="row">
                         <span>Difficulty</span>
                         <select id="optDifficulty">

--- a/styles.css
+++ b/styles.css
@@ -439,6 +439,12 @@ dialog::backdrop {
     margin: 0;
 }
 
+#optionsDialog .grid-size-control {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .dialog-content h2 {
     letter-spacing: 0.1em;
     text-transform: uppercase;

--- a/styles.css
+++ b/styles.css
@@ -433,6 +433,7 @@ dialog::backdrop {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1rem;
+    font-size: 0.85rem;
 }
 
 #optionsDialog .options-grid .row {
@@ -480,6 +481,11 @@ dialog::backdrop {
     padding: 0.5rem;
     color: var(--text-primary);
     font-size: 0.9rem;
+}
+
+#optionsDialog input,
+#optionsDialog select {
+    font-size: 0.85rem;
 }
 
 .dialog-content input:focus,

--- a/styles.css
+++ b/styles.css
@@ -424,6 +424,21 @@ dialog::backdrop {
     padding: 2rem;
 }
 
+#optionsDialog {
+    width: 700px;
+    max-width: 95vw;
+}
+
+#optionsDialog .options-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+}
+
+#optionsDialog .options-grid .row {
+    margin: 0;
+}
+
 .dialog-content h2 {
     letter-spacing: 0.1em;
     text-transform: uppercase;

--- a/styles.css
+++ b/styles.css
@@ -440,10 +440,22 @@ dialog::backdrop {
     margin: 0;
 }
 
-#optionsDialog .grid-size-control {
+#optionsDialog .grid-size-option {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+#optionsDialog .grid-size-option .checkbox-line {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    width: 100%;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+#optionsDialog .grid-size-option select {
+    width: 100%;
 }
 
 .dialog-content h2 {


### PR DESCRIPTION
## Summary
- Widen loadout dialog and arrange options in two rows for better spacing
- Remove build tab header in game menu to maximize tower list area

## Testing
- `node tests/railgun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bcf4ac6c0883329c81233180c474bd