### PR TITLE
Show cat image during loading screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <div id="loadingScreen" class="loading-screen">Loading assets…</div>
+  <div id="loadingScreen" class="loading-screen">
+    <img src="./assets/animals/cat.png" alt="Loading..." />
+  </div>
 
     <main class="container menu-page war" aria-labelledby="gameTitle">
         <!-- ambient decor (sparks/embers) -->

--- a/styles.css
+++ b/styles.css
@@ -1294,3 +1294,8 @@ dialog::backdrop {
   font-size: 2rem;
   z-index: 1000;
 }
+
+.loading-screen img {
+  max-width: 200px;
+  height: auto;
+}

--- a/styles.css
+++ b/styles.css
@@ -1298,4 +1298,14 @@ dialog::backdrop {
 .loading-screen img {
   max-width: 200px;
   height: auto;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
## Summary
- Display a cat image while the game loads after hitting Start Mission
- Add styling to scale the loading-screen cat image

## Testing
- `node tests/railgun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd08583c248332b894587e89e15e9f